### PR TITLE
fix: garder aussi les code-barres EAN8

### DIFF
--- a/src/data/epicerie_connector.py
+++ b/src/data/epicerie_connector.py
@@ -38,7 +38,10 @@ class EpicerieConnector:
         pass
 
     def transform_products_codes(self):
-        self.products_codes = [code for code in self.products_codes if len(str(code)) == 13]
+        """
+        keep only EAN8 & EAN13 codes
+        """
+        self.products_codes = [code for code in self.products_codes if len(str(code)) in [8, 13]]
         if os.environ.get("DEBUG"):
             self.products_codes = self.products_codes[0:50]
 


### PR DESCRIPTION
### Quoi ?

On filtre déjà sur les code-barres EAN13. Il faudrait aussi inclure les EAN8.

https://fr.wikipedia.org/wiki/Code-barres_EAN

### Autre

cleanup du README (espacement, enlever lien vers notre API)