### PR TITLE
fix(API): accélérer un peu les appels API

### DIFF
--- a/src/data/off_connector.py
+++ b/src/data/off_connector.py
@@ -49,20 +49,11 @@ class OFFConnector:
         Need to respect the API Constraint of a maximum of 100 requests
         per minute
         """
-        start, end, step = 0, len(barcodes), 99
-        number_of_requests = 0
-        for i in range(start, end, step):
-            x = i
-            chunk = barcodes[x : x + step]
-            for barcode in chunk:
-                if number_of_requests == 99:
-                    logger.info("Waiting 60 seconds...")
-                    time.sleep(60)
-                    number_of_requests = 0
-
-                # A valid barcode is likely to have at least 10 digits
-                if len(str(barcode)) >= 10:
-                    product_fact = self.get_product_fact(barcode)
-                    if product_fact:
-                        self.products_facts.append(product_fact)
-                    number_of_requests += 1
+        for index, barcode in enumerate(barcodes):
+            product_fact = self.get_product_fact(barcode)
+            if product_fact:
+                self.products_facts.append(product_fact)
+            # Avoid too many calls to the API
+            # 1 second sleep every 10 API calls
+            if (index % 10) == 0:
+                time.sleep(1)

--- a/src/data/off_connector.py
+++ b/src/data/off_connector.py
@@ -54,6 +54,6 @@ class OFFConnector:
             if product_fact:
                 self.products_facts.append(product_fact)
             # Avoid too many calls to the API
-            # 1 second sleep every 10 API calls
+            # 5 second sleep every 10 API calls
             if (index % 10) == 0:
-                time.sleep(1)
+                time.sleep(5)


### PR DESCRIPTION
### Quoi ?

Au lieu d'un sleep de 60 secondes tous les 100 appels API, j'ai mis un sleep de 5 secondes tous les 10 appels API.
Cette PR est aussi là pour refactorer / simplifier ce code

### Pourquoi ?

Pour accélérer la synchro, elle prend environ 10 minutes actuellement