### PR TITLE
ci: Ajout de release-please pour automatiser les releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: simple

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,17 @@
+name: Semantic PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0 (2024-03-21)
+
+- Première version


### PR DESCRIPTION
### Quoi ?

Grâce à [release-please](https://github.com/google-github-actions/release-please-action) et aux [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) on a 
- des PR avec une nomenclature commune
- une PR qui sera ouverte avec les derniers changements sur `main`
- une fois mergée, cette PR générera une nouvelle release
  - en incrémentant le tag
  - et en mettant à jour le `CHANGELOG.md`