### PR TITLE
ci: Pusher automatiquement une nouvelle image Docker à chaque nouvelle release

### DIFF
--- a/.github/workflows/push-docker-image-to-docker-hub.yml
+++ b/.github/workflows/push-docker-image-to-docker-hub.yml
@@ -1,0 +1,30 @@
+name: Push Docker Image to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: |
+            lelefan/observatoireproduits:latest
+            lelefan/observatoireproduits:${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Quoi ?

On souhaite qu'à chaque nouvelle release (grâce à #13), cela génère une nouvelle image Docker et la push sur Docker Hub, avec comme tag le nom de cette release.