### PR TITLE
fix: Open Food Facts API: ajouter un user_agent pour authentifier nos requêtes

### DIFF
--- a/src/data/off_connector.py
+++ b/src/data/off_connector.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 # https://world.openfoodfacts.org/api/v2/product/3017620429484
 
 
+APP_USER_AGENT = "elefan-grenoble/observatoire_produits"
 OFF_FIELD_CODE = "code"
 OFF_FIELD_SELECTED_IMAGES = "selected_images"
 OFF_FIELDS_TO_EXPORT = [
@@ -35,7 +36,7 @@ OFF_FIELD_SELECTED_IMAGES_KEYS = ["front", "ingredients", "nutrition", "packagin
 class OFFConnector:
     def __init__(self) -> None:
         self.products_facts = []
-        self.api = openfoodfacts.API()
+        self.api = openfoodfacts.API(user_agent=APP_USER_AGENT)
 
     def get_product_fact(self, barcode):
         try:


### PR DESCRIPTION
### Quoi ?

Ajout d'un `user_agent` au nom du repo : `elefan-grenoble/observatoire_produit`

### Pourquoi ?

https://openfoodfacts.github.io/openfoodfacts-server/api/#authentication

> We ask you to always use a custom User-Agent to identify you (to not risk being identified as a bot). The User-Agent should be in the form of AppName/Version (ContactEmail). For example, MyApp/1.0 (contact@myapp.com).

