### PR TITLE
feat(Elefan): filtrer sur une liste de catégories à inclure (au lieu d'exclure)

### DIFF
--- a/src/data/elefan_connector.py
+++ b/src/data/elefan_connector.py
@@ -1,7 +1,6 @@
-import os
-
-import dotenv
 from epicerie_connector import EpicerieConnector
+import os
+import dotenv
 
 project_dir = os.path.join(os.path.dirname(__file__), os.pardir)
 dotenv_path = os.path.join(project_dir, ".env")
@@ -11,33 +10,29 @@ dotenv.load_dotenv(dotenv_path)
 class ElefanConnector(EpicerieConnector):
     def __init__(self) -> None:
         super().__init__()
-        self.codes_to_exclude = [
-            21,  # bebe (inclus nourriture)
-            22,  # hygiène, beauté
-            23,  # entretien, nettoyage
-            24,  # cuisine
-            25,  # santé
-            31,  # journaux
-            41,  # maison
-            42,  # papeterie
-            43,  # textile
-            44,  # animalerie
-            45,  # jardinerie
-            90,  # jeux
+        self.famille_code_food = [
+            1,  # fruits & légumes
+            2,  # épicerie salée
+            3,  # épicerie sucrée
+            4,  # boissons
+            5,  # pains & pâtisseries
+            11,  # viandes
+            12,  # produits laitiers
+            13,  # plats préparés
+            14,  # poissons
+            51,  # surgelés
         ]
 
     def filter_products(self):
         """
         epicerie-specific filtering rules:
+        - exclude products with a code starting with "2" (usually custom barcodes)
         - the product status must be "ACTIF"
         - for now, only handle "food" products
         """
+        self.products = [p for p in self.products if not p["code"].startswith("2")]
         self.products = [p for p in self.products if p["status"] == "ACTIF"]
-        self.products = [
-            p
-            for p in self.products
-            if p["famille"]["code"] not in self.codes_to_exclude
-        ]
+        self.products = [p for p in self.products if p["famille"]["code"] in self.famille_code_food]
 
     def extract_products_code_list(self):
         self.products_code_list = [p["code"] for p in self.products]


### PR DESCRIPTION
Changements sur le connecteur Elefan
- fournir une liste de catégories sur lequel filtrer (au lieu d'exclure)
- enlever les code-barres qui commencent par 2